### PR TITLE
Fix template rendering compatibility with Starlette 1.0

### DIFF
--- a/src/web/app.py
+++ b/src/web/app.py
@@ -108,6 +108,7 @@ def create_app() -> FastAPI:
     async def login_page(request: Request, next: Optional[str] = "/"):
         """登录页面"""
         return templates.TemplateResponse(
+            request,
             "login.html",
             {"request": request, "error": "", "next": next or "/"}
         )
@@ -118,6 +119,7 @@ def create_app() -> FastAPI:
         expected = get_settings().webui_access_password.get_secret_value()
         if not secrets.compare_digest(password, expected):
             return templates.TemplateResponse(
+                request,
                 "login.html",
                 {"request": request, "error": "密码错误", "next": next or "/"},
                 status_code=401
@@ -139,33 +141,33 @@ def create_app() -> FastAPI:
         """首页 - 注册页面"""
         if not _is_authenticated(request):
             return _redirect_to_login(request)
-        return templates.TemplateResponse("index.html", {"request": request})
+        return templates.TemplateResponse(request, "index.html", {"request": request})
 
     @app.get("/accounts", response_class=HTMLResponse)
     async def accounts_page(request: Request):
         """账号管理页面"""
         if not _is_authenticated(request):
             return _redirect_to_login(request)
-        return templates.TemplateResponse("accounts.html", {"request": request})
+        return templates.TemplateResponse(request, "accounts.html", {"request": request})
 
     @app.get("/email-services", response_class=HTMLResponse)
     async def email_services_page(request: Request):
         """邮箱服务管理页面"""
         if not _is_authenticated(request):
             return _redirect_to_login(request)
-        return templates.TemplateResponse("email_services.html", {"request": request})
+        return templates.TemplateResponse(request, "email_services.html", {"request": request})
 
     @app.get("/settings", response_class=HTMLResponse)
     async def settings_page(request: Request):
         """设置页面"""
         if not _is_authenticated(request):
             return _redirect_to_login(request)
-        return templates.TemplateResponse("settings.html", {"request": request})
+        return templates.TemplateResponse(request, "settings.html", {"request": request})
 
     @app.get("/payment", response_class=HTMLResponse)
     async def payment_page(request: Request):
         """支付页面"""
-        return templates.TemplateResponse("payment.html", {"request": request})
+        return templates.TemplateResponse(request, "payment.html", {"request": request})
 
     @app.on_event("startup")
     async def startup_event():

--- a/tests/test_static_asset_versioning.py
+++ b/tests/test_static_asset_versioning.py
@@ -1,5 +1,8 @@
 from pathlib import Path
+import asyncio
 import importlib
+
+from starlette.requests import Request
 
 web_app = importlib.import_module("src.web.app")
 
@@ -26,3 +29,30 @@ def test_index_template_uses_versioned_static_assets():
     assert '/static/css/style.css?v={{ static_version }}' in template
     assert '/static/js/utils.js?v={{ static_version }}' in template
     assert '/static/js/app.js?v={{ static_version }}' in template
+
+
+def test_login_page_renders_without_template_cache_error():
+    app = web_app.create_app()
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/login",
+        "raw_path": b"/login",
+        "query_string": b"",
+        "headers": [],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+    request = Request(scope)
+
+    login_route = next(route for route in app.routes if getattr(route, "path", None) == "/login" and "GET" in getattr(route, "methods", set()))
+
+    response = asyncio.run(login_route.endpoint(request, next="/"))
+
+    assert response.status_code == 200
+    assert "密码" in response.body.decode("utf-8")


### PR DESCRIPTION
Starlette 1.0 requires request as the first TemplateResponse argument, so update all template responses and add a login render regression check to prevent the unhashable dict runtime error.