### PR TITLE
fix(freemail): avoid reusing stale otp across phases

### DIFF
--- a/src/services/freemail.py
+++ b/src/services/freemail.py
@@ -8,6 +8,7 @@ import time
 import logging
 import random
 import string
+from datetime import datetime, timezone
 from typing import Optional, Dict, Any, List
 
 from .base import BaseEmailService, EmailServiceError, EmailServiceType
@@ -58,6 +59,38 @@ class FreemailService(BaseEmailService):
 
         # 缓存 domain 列表
         self._domains = []
+        # 记录每个邮箱上一次成功使用的邮件 ID，避免跨调用重复使用旧验证码
+        self._last_used_mail_ids: Dict[str, str] = {}
+
+    def _extract_mail_timestamp(self, mail: Dict[str, Any]) -> Optional[float]:
+        """尽力提取邮件时间戳（秒）用于 otp_sent_at 过滤。"""
+        for key in ("created_at", "createdAt", "date", "time"):
+            value = mail.get(key)
+            if value is None:
+                continue
+
+            if isinstance(value, (int, float)):
+                return float(value)
+
+            if isinstance(value, str):
+                text = value.strip()
+                if not text:
+                    continue
+
+                try:
+                    return float(text)
+                except ValueError:
+                    pass
+
+                try:
+                    dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=timezone.utc)
+                    return dt.timestamp()
+                except ValueError:
+                    continue
+
+        return None
 
     def _get_headers(self) -> Dict[str, str]:
         """构造 admin 请求头"""
@@ -202,6 +235,7 @@ class FreemailService(BaseEmailService):
 
         start_time = time.time()
         seen_mail_ids: set = set()
+        last_used_mail_id = self._last_used_mail_ids.get(email)
 
         while time.time() - start_time < timeout:
             try:
@@ -212,8 +246,13 @@ class FreemailService(BaseEmailService):
 
                 for mail in mails:
                     mail_id = mail.get("id")
-                    if not mail_id or mail_id in seen_mail_ids:
+                    if not mail_id or mail_id in seen_mail_ids or mail_id == last_used_mail_id:
                         continue
+
+                    if otp_sent_at is not None:
+                        mail_ts = self._extract_mail_timestamp(mail)
+                        if mail_ts is not None and mail_ts < otp_sent_at:
+                            continue
 
                     seen_mail_ids.add(mail_id)
 
@@ -230,6 +269,7 @@ class FreemailService(BaseEmailService):
                     v_code = mail.get("verification_code")
                     if v_code:
                         logger.info(f"从 Freemail 邮箱 {email} 找到验证码: {v_code}")
+                        self._last_used_mail_ids[email] = mail_id
                         self.update_status(True)
                         return v_code
 
@@ -238,6 +278,7 @@ class FreemailService(BaseEmailService):
                     if match:
                         code = match.group(1)
                         logger.info(f"从 Freemail 邮箱 {email} 找到验证码: {code}")
+                        self._last_used_mail_ids[email] = mail_id
                         self.update_status(True)
                         return code
 
@@ -249,6 +290,7 @@ class FreemailService(BaseEmailService):
                         if match:
                             code = match.group(1)
                             logger.info(f"从 Freemail 邮箱 {email} 找到验证码: {code}")
+                            self._last_used_mail_ids[email] = mail_id
                             self.update_status(True)
                             return code
                     except Exception as e:

--- a/tests/test_temp_mail_service.py
+++ b/tests/test_temp_mail_service.py
@@ -1,4 +1,5 @@
 from src.services.temp_mail import TempMailService
+from src.services.freemail import FreemailService
 
 
 class FakeResponse:
@@ -289,3 +290,82 @@ def test_get_verification_code_admin_unfiltered_fallback():
     code = service.get_verification_code(email="target@example.com", timeout=1)
 
     assert code == "135790"
+
+
+def test_freemail_get_verification_code_skips_last_used_mail_id_between_calls():
+    service = FreemailService({
+        "base_url": "https://mail.example.com",
+        "admin_token": "admin-token",
+    })
+    fake_client = FakeHTTPClient([
+        FakeResponse(
+            payload=[
+                {
+                    "id": "mail-1",
+                    "sender": "noreply@openai.com",
+                    "subject": "Code #1",
+                    "preview": "111111 is your verification code",
+                }
+            ]
+        ),
+        FakeResponse(
+            payload=[
+                {
+                    "id": "mail-1",
+                    "sender": "noreply@openai.com",
+                    "subject": "Code #1",
+                    "preview": "111111 is your verification code",
+                },
+                {
+                    "id": "mail-2",
+                    "sender": "noreply@openai.com",
+                    "subject": "Code #2",
+                    "preview": "222222 is your verification code",
+                },
+            ]
+        ),
+    ])
+    service.http_client = fake_client
+
+    code_1 = service.get_verification_code(email="reuse@example.com", timeout=1)
+    code_2 = service.get_verification_code(email="reuse@example.com", timeout=1)
+
+    assert code_1 == "111111"
+    assert code_2 == "222222"
+
+
+def test_freemail_get_verification_code_filters_old_mails_by_otp_sent_at():
+    service = FreemailService({
+        "base_url": "https://mail.example.com",
+        "admin_token": "admin-token",
+    })
+    otp_sent_at = 1_700_000_000.0
+    fake_client = FakeHTTPClient([
+        FakeResponse(
+            payload=[
+                {
+                    "id": "mail-old",
+                    "sender": "noreply@openai.com",
+                    "subject": "Old Code",
+                    "preview": "333333 is your verification code",
+                    "createdAt": otp_sent_at - 30,
+                },
+                {
+                    "id": "mail-new",
+                    "sender": "noreply@openai.com",
+                    "subject": "New Code",
+                    "preview": "444444 is your verification code",
+                    "createdAt": otp_sent_at + 5,
+                },
+            ]
+        ),
+    ])
+    service.http_client = fake_client
+
+    code = service.get_verification_code(
+        email="filter@example.com",
+        timeout=1,
+        otp_sent_at=otp_sent_at,
+    )
+
+    assert code == "444444"


### PR DESCRIPTION
## Summary
Fix Freemail OTP retrieval so the login phase does not accidentally reuse a stale OTP email/code from the earlier registration phase.

## Problem
In the registration flow, Freemail mailboxes could already contain multiple OpenAI OTP emails. The registration-phase OTP succeeded, but the later login-phase OTP retrieval could reuse the old mail/code again, causing OpenAI OTP validation to fail with 401 even though newer login OTP emails already existed in the mailbox.

## Root cause
	src/services/freemail.py only tracked seen_mail_ids inside a single polling call.
It did not persist cross-call state for already-consumed mail IDs, and it did not sufficiently filter old mails using otp_sent_at.

## Fix
- add per-mailbox tracking for last used mail id
- add mail timestamp extraction for otp_sent_at filtering
- skip previously used mail ids across calls
- remember the mail id after successfully extracting a code

## Verification
............                                                             [100%]
=============================== warnings summary ===============================
src/database/models.py:13
  /Users/mrcagents/Work/projects/codex-console/src/database/models.py:13: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    Base = declarative_base()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

Result: PASS

## Scope
- narrow patch only
- no deploy/runtime config changes
